### PR TITLE
transfer up to 100 tracks per playlist

### DIFF
--- a/frontend/src/Api/createTidalPlaylist.ts
+++ b/frontend/src/Api/createTidalPlaylist.ts
@@ -1,0 +1,15 @@
+import type { Playlist, TidalPlaylistId } from '../Types/Playlist';
+import { apiInstance } from './utils';
+
+export async function createTidalPlaylist(playlist: Playlist, state: string): Promise<TidalPlaylistId> {
+  const response = await apiInstance.post('api/tidal/playlists', null, {
+    params: {
+      accessType: playlist.public ? 'Public' : 'Private',
+      description: 'template',
+      name: playlist.name,
+      state: state,
+    },
+  });
+
+  return response.data;
+}

--- a/frontend/src/Api/fetchPlaylistTracks.ts
+++ b/frontend/src/Api/fetchPlaylistTracks.ts
@@ -1,9 +1,8 @@
+import type { PlaylistTrack } from '../Types/Tracks';
 import { apiInstance } from './utils';
-import type { PlaylistTracksDetailed } from '../Types/Tracks';
-
-export async function fetchPlaylistTracks(state: string, playlistId: string): Promise<PlaylistTracksDetailed> {
+export async function fetchPlaylistTracksDetailed(state: string, playlistId: string): Promise<PlaylistTrack[]> {
   const response = await apiInstance.get(`api/Spotify/playlist/${playlistId}`, {
     params: { state },
   });
-  return response.data;
+  return response.data.tracks.items;
 }

--- a/frontend/src/Api/fetchTidalSearchTrack.ts
+++ b/frontend/src/Api/fetchTidalSearchTrack.ts
@@ -1,0 +1,9 @@
+import type { TidalTrackId } from '../Types/Tracks';
+import { apiInstance } from './utils';
+
+export async function fetchTidalSearchTrack(state: string, isrc: string): Promise<TidalTrackId> {
+  const response = await apiInstance.get(`api/tidal/track/${isrc}`, {
+    params: { state },
+  });
+  return await response.data[0];
+}

--- a/frontend/src/Api/populatePlaylist.ts
+++ b/frontend/src/Api/populatePlaylist.ts
@@ -1,0 +1,35 @@
+import type { TidalPlaylistId } from '../Types/Playlist';
+import { apiInstance } from './utils';
+
+export async function populatePlaylist(tidalPlaylistId: TidalPlaylistId, tidalTrackIds: string[], state: string) {
+  const id = tidalPlaylistId.data.id;
+
+  console.log(`Adding ${tidalTrackIds.length} tracks in batches of 20...`);
+  const chunkSize = 20;
+  const chunks = [];
+  const results = [];
+  for (let i = 0; i < tidalTrackIds.length; i += chunkSize) {
+    chunks.push(tidalTrackIds.slice(i, i + chunkSize));
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    console.log(`Sending batch ${i + 1}/${chunks.length} (${chunk.length} tracks)`);
+    try {
+      const response = await apiInstance.post(`/api/tidal/playlists/${id}/track`, chunk, {
+        params: { state },
+      });
+
+      results.push(response.data);
+      console.log(`Successfully added batch ${i + 1}/${chunks.length}`);
+
+      if (i < chunks.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    } catch (error) {
+      console.error(`Error adding batch ${i + 1}:`, error);
+      throw error;
+    }
+  }
+  return results;
+}

--- a/frontend/src/Types/Playlist.ts
+++ b/frontend/src/Types/Playlist.ts
@@ -16,6 +16,12 @@ export type PlaylistApi = {
   public: boolean;
   tracks: PlaylistTracks;
 };
+
+export type TidalPlaylistId = {
+  data: {
+    id: string;
+  };
+};
 export type Playlist = PlaylistApi & {
   picked: boolean;
   tracksDetailed: PlaylistTracksDetailed | null;

--- a/frontend/src/Types/Tracks.ts
+++ b/frontend/src/Types/Tracks.ts
@@ -1,11 +1,12 @@
-type PlaylistTrack = {
-  id: string;
-  name: string;
-  external_ids: {
-    isrc: string;
+export type PlaylistTrack = {
+  track: {
+    id: string;
+    name: string;
+    external_ids: {
+      isrc: string;
+    };
   };
 };
-export type PlaylistTracksDetailed = {
-  href: string;
-  items: PlaylistTrack[];
+export type TidalTrackId = {
+  id: string;
 };

--- a/frontend/src/routes/transfer/success.tsx
+++ b/frontend/src/routes/transfer/success.tsx
@@ -1,19 +1,58 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useSearch } from '@tanstack/react-router';
 import { useGetPlaylists } from '../../Api/useGetPlaylists';
 import { PlaylistCard } from '../../Components/PlaylistCard';
 import type { Playlist } from '../../Types/Playlist';
 import { useEffect, useState } from 'react';
 import { Button } from '../../Components/Button';
-import { fetchPlaylistTracks } from '../../Api/fetchPlaylistTracks';
+import { fetchPlaylistTracksDetailed } from '../../Api/fetchPlaylistTracks';
+import type { RedirParam } from '../../Types/Auth';
+import { fetchTidalSearchTrack } from '../../Api/fetchTidalSearchTrack';
+import { createTidalPlaylist } from '../../Api/createTidalPlaylist';
+import type { PlaylistTrack } from '../../Types/Tracks';
+import { populatePlaylist } from '../../Api/populatePlaylist';
 
 export const Route = createFileRoute('/transfer/success')({
   component: RouteComponent,
 });
 
+async function findTidalTracks(playlistItems: PlaylistTrack[], tidalTrackIds: string[], toState: string) {
+  const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+  let foundCount = 0;
+  let skippedCount = 0;
+  for (const element of playlistItems) {
+    const isrc = element.track.external_ids.isrc;
+
+    if (!isrc) {
+      console.warn('Skipping track without ISRC:', element.track.name);
+      skippedCount++;
+      continue;
+    }
+    try {
+      const foundTrackId = await fetchTidalSearchTrack(toState, isrc);
+      if (!foundTrackId || !foundTrackId.id) {
+        console.warn('Track not on tidal', element.track.name);
+        skippedCount++;
+        continue;
+      }
+
+      tidalTrackIds.push(foundTrackId.id);
+      foundCount++;
+      await delay(300);
+    } catch (error) {
+      console.error('Error searching for track:', element.track.name, error);
+      skippedCount++;
+    }
+  }
+  console.log(`Found ${foundCount} tracks, skipped ${skippedCount} tracks`);
+}
+
 function RouteComponent() {
   const fromState = localStorage.getItem('fromState') ?? '';
+  const toStateQuery: RedirParam = useSearch({ from: '/transfer/success' });
   const { data, isLoading, isError } = useGetPlaylists(fromState);
   const [playlists, setPlaylists] = useState<Playlist[] | null>(null);
+
+  const toState = toStateQuery.state;
 
   useEffect(() => {
     if (data) {
@@ -39,19 +78,59 @@ function RouteComponent() {
       return prev.map((pl) => ({ ...pl, picked: !allPicked }));
     });
   };
+
   const transferSongs = async () => {
     const pickedPlaylists = playlists?.filter((playlist) => {
       return playlist.picked === true;
     });
-    if (!pickedPlaylists) return;
-    pickedPlaylists.forEach(async (playlist) => {
-      const id = playlist.id;
-      console.log(id);
-      console.log(fromState);
-      const tracks = await fetchPlaylistTracks(fromState, id);
-      playlist.tracksDetailed = tracks;
-    });
+
+    if (!pickedPlaylists || pickedPlaylists.length === 0) {
+      console.warn('No playlists selected');
+      return;
+    }
+
+    console.log(`Starting transfer of ${pickedPlaylists.length} playlists`);
+
+    for (const playlist of pickedPlaylists) {
+      const spotifyPlaylistId = playlist.id;
+
+      if (!spotifyPlaylistId) {
+        console.error('Playlist missing ID:', playlist.name);
+        continue;
+      }
+      console.log(`Processing playlist: ${playlist.name}`);
+
+      const tidalTrackIds: string[] = [];
+
+      try {
+        const tracksDetailed = await fetchPlaylistTracksDetailed(fromState, spotifyPlaylistId);
+        console.log(`Found ${tracksDetailed.length} tracks in playlist`);
+
+        const tidalPlaylistId = await createTidalPlaylist(playlist, toState);
+        if (!tidalPlaylistId) {
+          console.error('Failed to create Tidal playlist for:', playlist.name);
+          continue;
+        }
+        console.log(`Created Tidal playlist with ID: ${tidalPlaylistId.data.id}`);
+
+        await findTidalTracks(tracksDetailed, tidalTrackIds, toState);
+
+        if (tidalTrackIds.length === 0) {
+          console.warn('No tracks found on Tidal for playlist:', playlist.name);
+          continue;
+        }
+
+        console.log(`Populating playlist with ${tidalTrackIds.length} tracks`);
+
+        await populatePlaylist(tidalPlaylistId, tidalTrackIds, toState);
+
+        console.log(`Successfully transferred playlist: ${playlist.name}`);
+      } catch (error) {
+        console.error(`Error transferring playlist ${playlist.name}:`, error);
+      }
+    }
   };
+
   if (isLoading) {
     return <></>;
   }


### PR DESCRIPTION
-for now limited to 100 tracks per playlist, will increase limits in upcoming PRs
-populate playlists is divided per chunks because you can only add 20 songs per POST
-console logging everything for now for better testing, will visually represent the status on frontend later